### PR TITLE
Спринт №27

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,6 +8,7 @@ android {
 
     buildFeatures {
         viewBinding = true
+        compose = true
     }
 
     namespace = "com.example.playlistmaker"
@@ -39,6 +40,9 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.8" // версия совместимая с Kotlin 1.9.22
+    }
 }
 
 dependencies {
@@ -62,4 +66,10 @@ dependencies {
     implementation("androidx.fragment:fragment-ktx:1.8.6")
     implementation ("androidx.navigation:navigation-fragment-ktx:2.8.9")
     implementation ("androidx.navigation:navigation-ui-ktx:2.8.9")
+
+    implementation ("androidx.compose.ui:ui:1.6.1")
+    implementation ("androidx.compose.material:material:1.6.1")
+    implementation ("androidx.activity:activity-compose:1.8.2")
+    debugImplementation("androidx.compose.ui:ui-tooling:1.6.2")
+    implementation("androidx.compose.runtime:runtime-livedata:1.6.4")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,4 +72,5 @@ dependencies {
     implementation ("androidx.activity:activity-compose:1.8.2")
     debugImplementation("androidx.compose.ui:ui-tooling:1.6.2")
     implementation("androidx.compose.runtime:runtime-livedata:1.6.4")
+    implementation("io.coil-kt:coil-compose:2.4.0")
 }

--- a/app/src/main/java/com/example/playlistmaker/media/ui/CreatePlaylistFragment.kt
+++ b/app/src/main/java/com/example/playlistmaker/media/ui/CreatePlaylistFragment.kt
@@ -19,6 +19,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import com.bumptech.glide.Glide
 import com.example.playlistmaker.R
 import com.example.playlistmaker.databinding.FragmentCreatePlaylistBinding
 import com.example.playlistmaker.media.view_model.CreatePlaylistViewModel
@@ -68,7 +69,10 @@ open class CreatePlaylistFragment : Fragment() {
 
         val pickMedia = registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
             if (uri != null) {
-                binding.image.setImageURI(uri)
+                Glide.with(this)
+                    .load(uri)
+                    .centerCrop()
+                    .into(binding.image)
                 saveImageToPrivateStorage(uri)
             }
         }

--- a/app/src/main/java/com/example/playlistmaker/media/ui/CreatePlaylistFragment.kt
+++ b/app/src/main/java/com/example/playlistmaker/media/ui/CreatePlaylistFragment.kt
@@ -114,7 +114,7 @@ open class CreatePlaylistFragment : Fragment() {
         BitmapFactory.decodeStream(inputStream).compress(Bitmap.CompressFormat.JPEG, 30, outputStream)
         inputStream?.close()
         outputStream.close()
-        viewModel.onImagePathChanged(uri.toString())
+        viewModel.onImagePathChanged(file.absolutePath)
     }
 
     private fun showExitConfirmationDialog() {

--- a/app/src/main/java/com/example/playlistmaker/media/ui/FavoritesFragmentCompose.kt
+++ b/app/src/main/java/com/example/playlistmaker/media/ui/FavoritesFragmentCompose.kt
@@ -1,0 +1,129 @@
+package com.example.playlistmaker.media.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import com.example.playlistmaker.R
+import com.example.playlistmaker.media.view_model.FavoritesScreenState
+import com.example.playlistmaker.media.view_model.FavoritesViewModel
+import com.example.playlistmaker.search.domain.models.Track
+import com.example.playlistmaker.universalUiComponents.ErrorView
+import com.example.playlistmaker.universalUiComponents.LoadingIndicator
+import com.example.playlistmaker.universalUiComponents.TrackItem
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.koin.androidx.viewmodel.ext.android.viewModel
+
+class FavoritesFragmentCompose : Fragment() {
+
+    private val viewModel: FavoritesViewModel by viewModel()
+    private var isClickAllowed = true
+    private val clickDebounceDelay = 1000L
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                FavoritesScreen(
+                    viewModel = viewModel,
+                    onTrackClick = { track ->
+                        if (clickDebounce()) {
+                            startTrackFragment(track)
+                        }
+                    }
+                )
+            }
+        }
+    }
+
+    private fun startTrackFragment(track: Track) {
+        viewModel.saveForAudioPlayer(track)
+        viewLifecycleOwner.lifecycleScope.launch {
+            delay(1000)
+            findNavController().navigate(R.id.action_global_to_trackFragment)
+        }
+    }
+
+    private fun clickDebounce(): Boolean {
+        val current = isClickAllowed
+        if (isClickAllowed) {
+            isClickAllowed = false
+            viewLifecycleOwner.lifecycleScope.launch {
+                delay(clickDebounceDelay)
+                isClickAllowed = true
+            }
+        }
+        return current
+    }
+
+    @Composable
+    fun FavoritesScreen(
+        viewModel: FavoritesViewModel,
+        onTrackClick: (Track) -> Unit
+    ) {
+        val state by viewModel.screenState.collectAsState()
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(colorResource(id = R.color.defaultBackground)),
+            contentAlignment = Alignment.Center
+        ) {
+            when (state) {
+                is FavoritesScreenState.Loading -> {
+                    LoadingIndicator()
+                }
+
+                is FavoritesScreenState.Content -> {
+                    val tracks = (state as FavoritesScreenState.Content).tracks
+
+                    if (tracks.isEmpty()) {
+                        ErrorView(
+                            icon = painterResource(id = R.drawable.track_not_found),
+                            text = stringResource(R.string.favorites_empty),
+                            showRetry = false,
+                            onRetry = {}
+                        )
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(top = 12.dp)
+                        ) {
+                            items(tracks) { track ->
+                                TrackItem(
+                                    track = track,
+                                    onClick = { onTrackClick(track) }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/example/playlistmaker/media/ui/MediaFragmentCompose.kt
+++ b/app/src/main/java/com/example/playlistmaker/media/ui/MediaFragmentCompose.kt
@@ -90,7 +90,7 @@ class MediaFragmentCompose : Fragment() {
             ) { page ->
                 when (page) {
                     0 -> FragmentContainer(fragment = { FavoritesFragmentCompose() })
-                    1 -> FragmentContainer(fragment = { PlaylistsFragment() })
+                    1 -> FragmentContainer(fragment = { PlaylistsFragmentCompose() })
                 }
             }
         }

--- a/app/src/main/java/com/example/playlistmaker/media/ui/MediaFragmentCompose.kt
+++ b/app/src/main/java/com/example/playlistmaker/media/ui/MediaFragmentCompose.kt
@@ -1,0 +1,135 @@
+package com.example.playlistmaker.media.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.Tab
+import androidx.compose.material.TabRow
+import androidx.compose.material.TabRowDefaults
+import androidx.compose.material.TabRowDefaults.tabIndicatorOffset
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentContainerView
+import com.example.playlistmaker.R
+import com.example.playlistmaker.universalUiComponents.CustomTopBar
+import kotlinx.coroutines.launch
+
+class MediaFragmentCompose : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MediaScreen()
+            }
+        }
+    }
+
+    @OptIn(ExperimentalFoundationApi::class)
+    @Composable
+    fun MediaScreen() {
+        val scope = rememberCoroutineScope()
+        val pagerState = rememberPagerState(initialPage = 0, pageCount = { 2 })
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(colorResource(R.color.defaultBackground))
+        ) {
+            CustomTopBar(titleText = stringResource(R.string.media))
+
+            TabRow(
+                selectedTabIndex = pagerState.currentPage,
+                modifier = Modifier.fillMaxWidth(),
+                backgroundColor = colorResource(id = R.color.defaultBackground),
+                contentColor = colorResource(id = R.color.defaultTextColor),
+                indicator = { tabPositions ->
+                    TabRowDefaults.Indicator(
+                        Modifier.tabIndicatorOffset(tabPositions[pagerState.currentPage]),
+                        color = colorResource(id = R.color.defaultTextColor)
+                    )
+                }
+            ) {
+                CustomTab(
+                    text = stringResource(id = R.string.favorites),
+                    selected = pagerState.currentPage == 0,
+                    onClick = { scope.launch { pagerState.animateScrollToPage(0) } }
+                )
+                CustomTab(
+                    text = stringResource(id = R.string.playlists),
+                    selected = pagerState.currentPage == 1,
+                    onClick = { scope.launch { pagerState.animateScrollToPage(1) } }
+                )
+            }
+
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.fillMaxSize()
+            ) { page ->
+                when (page) {
+                    0 -> FragmentContainer(fragment = { FavoritesFragment() })
+                    1 -> FragmentContainer(fragment = { PlaylistsFragment() })
+                }
+            }
+        }
+    }
+
+    @Composable
+    fun FragmentContainer(fragment: () -> Fragment) {
+        AndroidView(
+            modifier = Modifier.fillMaxSize(),
+            factory = { context ->
+                FragmentContainerView(context).apply {
+                    id = View.generateViewId()
+                    (context as AppCompatActivity).supportFragmentManager
+                        .beginTransaction()
+                        .replace(id, fragment())
+                        .commit()
+                }
+            }
+        )
+    }
+
+    @Composable
+    fun CustomTab(
+        text: String,
+        selected: Boolean,
+        onClick: () -> Unit
+    ) {
+        Tab(
+            selected = selected,
+            onClick = onClick,
+            text = {
+                Text(
+                    text = text,
+                    color = colorResource(id = R.color.defaultTextColor),
+                    fontFamily = FontFamily(Font(R.font.ys_display_medium)),
+                    fontSize = 14.sp
+                )
+            }
+        )
+    }
+
+}

--- a/app/src/main/java/com/example/playlistmaker/media/ui/MediaFragmentCompose.kt
+++ b/app/src/main/java/com/example/playlistmaker/media/ui/MediaFragmentCompose.kt
@@ -89,7 +89,7 @@ class MediaFragmentCompose : Fragment() {
                 modifier = Modifier.fillMaxSize()
             ) { page ->
                 when (page) {
-                    0 -> FragmentContainer(fragment = { FavoritesFragment() })
+                    0 -> FragmentContainer(fragment = { FavoritesFragmentCompose() })
                     1 -> FragmentContainer(fragment = { PlaylistsFragment() })
                 }
             }

--- a/app/src/main/java/com/example/playlistmaker/media/ui/MediaFragmentCompose.kt
+++ b/app/src/main/java/com/example/playlistmaker/media/ui/MediaFragmentCompose.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.TabRowDefaults
 import androidx.compose.material.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
@@ -98,11 +99,12 @@ class MediaFragmentCompose : Fragment() {
 
     @Composable
     fun FragmentContainer(fragment: () -> Fragment) {
+        val fragmentContainerId = remember { View.generateViewId() }
         AndroidView(
             modifier = Modifier.fillMaxSize(),
             factory = { context ->
                 FragmentContainerView(context).apply {
-                    id = View.generateViewId()
+                    id = fragmentContainerId
                     (context as AppCompatActivity).supportFragmentManager
                         .beginTransaction()
                         .replace(id, fragment())

--- a/app/src/main/java/com/example/playlistmaker/media/ui/PlaylistDetailsFragment.kt
+++ b/app/src/main/java/com/example/playlistmaker/media/ui/PlaylistDetailsFragment.kt
@@ -7,7 +7,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
-import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -24,6 +23,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import java.io.File
 
 class PlaylistDetailsFragment : Fragment() {
 
@@ -102,11 +102,12 @@ class PlaylistDetailsFragment : Fragment() {
 
     private fun loadTrackInfo(screenState: PlaylistDetailsScreenState.Content) {
         if (!screenState.playlist?.playlistImageUrl.isNullOrEmpty()) {
+            val imageFile = File(screenState.playlist?.playlistImageUrl ?: "")
             Glide.with(this@PlaylistDetailsFragment)
-                .load(screenState.playlist?.playlistImageUrl?.toUri())
+                .load(imageFile)
                 .placeholder(R.drawable.placeholder_full_size).into(binding.plPlaylistImage)
             Glide.with(this@PlaylistDetailsFragment)
-                .load(screenState.playlist?.playlistImageUrl?.toUri())
+                .load(imageFile)
                 .placeholder(R.drawable.placeholder_full_size).into(itemBinding.rvSmPlaylistImage)
         } else {
             binding.plPlaylistImage.setImageResource(R.drawable.placeholder_full_size)

--- a/app/src/main/java/com/example/playlistmaker/media/ui/PlaylistsFragment.kt
+++ b/app/src/main/java/com/example/playlistmaker/media/ui/PlaylistsFragment.kt
@@ -30,7 +30,7 @@ class PlaylistsFragment : Fragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         binding = FragmentPlaylistsBinding.inflate(inflater, container, false)
         binding.createPlaylist.setOnClickListener {
-            requireParentFragment().requireParentFragment().findNavController()?.navigate(R.id.action_media_to_newPlaylist)
+            requireParentFragment().requireParentFragment().findNavController().navigate(R.id.action_media_to_newPlaylist)
         }
         return binding.root
     }
@@ -69,7 +69,7 @@ class PlaylistsFragment : Fragment() {
             val bundle = Bundle().apply {
                 putLong("playlistId", playlist.playlistId ?: -1L)
             }
-            requireParentFragment().requireParentFragment().findNavController()?.navigate(R.id.action_media_to_playlistDetails, bundle)
+            findNavController().navigate(R.id.action_media_to_playlistDetails, bundle)
         }
 
     }

--- a/app/src/main/java/com/example/playlistmaker/media/ui/PlaylistsFragmentCompose.kt
+++ b/app/src/main/java/com/example/playlistmaker/media/ui/PlaylistsFragmentCompose.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -23,9 +24,11 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.material.Text
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -171,7 +174,7 @@ class PlaylistsFragmentCompose : Fragment() {
             modifier = Modifier
                 .padding(4.dp)
                 .width(160.dp)
-                .clickable { onClick() },
+                .clickable(onClick = onClick, indication = rememberRipple(bounded = true), interactionSource = remember { MutableInteractionSource() }),
             elevation = 0.dp,
             backgroundColor = colorResource(id = R.color.defaultBackground)
         ) {

--- a/app/src/main/java/com/example/playlistmaker/media/ui/PlaylistsFragmentCompose.kt
+++ b/app/src/main/java/com/example/playlistmaker/media/ui/PlaylistsFragmentCompose.kt
@@ -138,10 +138,12 @@ class PlaylistsFragmentCompose : Fragment() {
                     horizontalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     items(playlists) { playlist ->
-                        PlaylistItem(
-                            playlist = playlist,
-                            onClick = { onPlaylistClick(playlist.playlistId ?: -1L) }
-                        )
+                        playlist.playlistId?.let { id ->
+                            PlaylistItem(
+                                playlist = playlist,
+                                onClick = { onPlaylistClick(id) }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/example/playlistmaker/media/ui/PlaylistsFragmentCompose.kt
+++ b/app/src/main/java/com/example/playlistmaker/media/ui/PlaylistsFragmentCompose.kt
@@ -1,0 +1,229 @@
+package com.example.playlistmaker.media.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Card
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import coil.compose.rememberAsyncImagePainter
+import coil.request.ImageRequest.Builder
+import com.example.playlistmaker.R
+import com.example.playlistmaker.media.domain.models.Playlist
+import com.example.playlistmaker.media.view_model.PlaylistScreenState
+import com.example.playlistmaker.media.view_model.PlaylistsViewModel
+import com.example.playlistmaker.universalUiComponents.ActionButton
+import com.example.playlistmaker.universalUiComponents.ErrorView
+import com.example.playlistmaker.universalUiComponents.LoadingIndicator
+import org.koin.androidx.viewmodel.ext.android.viewModel
+
+class PlaylistsFragmentCompose : Fragment() {
+
+    private val viewModel: PlaylistsViewModel by viewModel()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                PlaylistsScreen(
+                    viewModel = viewModel,
+                    onPlaylistClick = { playlistId ->
+                        findNavController().navigate(
+                            R.id.action_media_to_playlistDetails,
+                            Bundle().apply { putLong("playlistId", playlistId) }
+                        )
+                    },
+                    onCreatePlaylistClick = {
+                        findNavController().navigate(R.id.action_media_to_newPlaylist)
+                    }
+                )
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.loadPlaylists()
+    }
+
+    @Composable
+    fun PlaylistsScreen(
+        viewModel: PlaylistsViewModel,
+        onPlaylistClick: (Long) -> Unit,
+        onCreatePlaylistClick: () -> Unit
+    ) {
+        val state by viewModel.screenState.collectAsState()
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(colorResource(R.color.defaultBackground))
+        ) {
+            // Верхний блок: кнопка и сообщение об ошибке
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Spacer(modifier = Modifier.height(16.dp))
+
+                ActionButton(stringResource(R.string.create_playlist), onCreatePlaylistClick)
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                if (state is PlaylistScreenState.Content && (state as PlaylistScreenState.Content).playlists.isEmpty()) {
+                    ErrorView(
+                        icon = painterResource(R.drawable.track_not_found),
+                        text = stringResource(R.string.playlists_empty),
+                        showRetry = false,
+                        onRetry = {},
+                        modifier = Modifier.padding(top = 16.dp)
+                    )
+                }
+            }
+
+            // Список занимает оставшееся место
+            if (state is PlaylistScreenState.Content && (state as PlaylistScreenState.Content).playlists.isNotEmpty()) {
+                val playlists = (state as PlaylistScreenState.Content).playlists
+
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(2),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .padding(8.dp),
+                    contentPadding = PaddingValues(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    items(playlists) { playlist ->
+                        PlaylistItem(
+                            playlist = playlist,
+                            onClick = { onPlaylistClick(playlist.playlistId ?: -1L) }
+                        )
+                    }
+                }
+            }
+
+            // Загрузка в любом случае сверху
+            if (state is PlaylistScreenState.Loading) {
+                LoadingIndicator()
+            }
+        }
+    }
+
+
+    @Composable
+    fun PlaylistItem(
+        playlist: Playlist,
+        onClick: () -> Unit
+    ) {
+        val painter = rememberAsyncImagePainter(Builder(LocalContext.current).data(data = playlist.playlistImageUrl ?: "").apply(block = { ->
+            placeholder(R.drawable.placeholder)
+            error(R.drawable.placeholder)
+            crossfade(true)
+        }).build())
+
+        Card(
+            modifier = Modifier
+                .padding(4.dp)
+                .width(160.dp)
+                .clickable { onClick() },
+            elevation = 0.dp,
+            backgroundColor = colorResource(id = R.color.defaultBackground)
+        ) {
+            Column {
+                Image(
+                    painter = painter,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(160.dp)
+                        .clip(RoundedCornerShape(4.dp)),
+                    contentScale = ContentScale.Crop
+                )
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                Column(
+                    modifier = Modifier
+                        .height(32.dp)
+                        .padding(horizontal = 4.dp),
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(
+                        text = playlist.playlistName ?: "",
+                        color = colorResource(R.color.defaultTextColor),
+                        fontSize = 12.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        fontFamily = FontFamily(Font(R.font.ys_display_regular))
+                    )
+
+                    val trackCountText = if (!playlist.trackIds.isNullOrEmpty()) {
+                        val count = playlist.trackIds.count()
+                        pluralStringResource(id = R.plurals.track_count, count = count, count)
+                    } else {
+                        "0 треков"
+                    }
+
+                    Text(
+                        text = trackCountText,
+                        color = colorResource(R.color.defaultTextColor),
+                        fontSize = 12.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        fontFamily = FontFamily(Font(R.font.ys_display_regular))
+                    )
+                }
+            }
+        }
+    }
+
+
+}
+
+
+
+
+

--- a/app/src/main/java/com/example/playlistmaker/search/ui/SearchFragmentCompose.kt
+++ b/app/src/main/java/com/example/playlistmaker/search/ui/SearchFragmentCompose.kt
@@ -160,7 +160,8 @@ class SearchFragmentCompose : Fragment() {
                         icon = painterResource(R.drawable.track_search_error),
                         text = stringResource(R.string.connection_error),
                         showRetry = error.showRefresh,
-                        onRetry = onRetry
+                        onRetry = onRetry,
+                        modifier = Modifier.padding(top = 100.dp).fillMaxWidth()
                     )
                 }
             }
@@ -180,7 +181,8 @@ class SearchFragmentCompose : Fragment() {
                 icon = painterResource(R.drawable.track_not_found),
                 text = stringResource(R.string.nothing_found),
                 showRetry = false,
-                onRetry = {}
+                onRetry = {},
+                modifier = Modifier.padding(top = 100.dp).fillMaxWidth()
             )
         } else {
             LazyColumn(

--- a/app/src/main/java/com/example/playlistmaker/search/ui/SearchFragmentCompose.kt
+++ b/app/src/main/java/com/example/playlistmaker/search/ui/SearchFragmentCompose.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -74,7 +73,7 @@ class SearchFragmentCompose : Fragment() {
 
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+
                     SearchScreen(
                         viewModel = viewModel,
                         onTrackClick = ::handleTrackClick,
@@ -83,7 +82,6 @@ class SearchFragmentCompose : Fragment() {
                         onRetry = { viewModel.searchDebounce(viewModel.lastQuery) },
                         onClearSearch = { viewModel.searchDebounce("") }
                     )
-                }
             }
         }
     }
@@ -93,7 +91,7 @@ class SearchFragmentCompose : Fragment() {
             viewModel.saveTrackToHistory(track)
             viewModel.saveForAudioPlayer(track)
             viewLifecycleOwner.lifecycleScope.launch {
-                delay(1000)
+                delay(clickDebounceDelay)
                 findNavController().navigate(R.id.action_global_to_trackFragment)
             }
         }
@@ -212,7 +210,6 @@ class SearchFragmentCompose : Fragment() {
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(top = 24.dp)
-                        .weight(1f)
                 ) {
                     items(state.historyTracks) { track ->
                         TrackItem(track = track, onClick = { onHistoryTrackClick(track) })

--- a/app/src/main/java/com/example/playlistmaker/search/ui/SearchFragmentCompose.kt
+++ b/app/src/main/java/com/example/playlistmaker/search/ui/SearchFragmentCompose.kt
@@ -1,0 +1,411 @@
+package com.example.playlistmaker.search.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.activity.OnBackPressedCallback
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import com.bumptech.glide.Glide
+import com.example.playlistmaker.R
+import com.example.playlistmaker.search.domain.models.Track
+import com.example.playlistmaker.search.view_model.SearchScreenState
+import com.example.playlistmaker.search.view_model.SearchViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.koin.androidx.viewmodel.ext.android.viewModel
+
+
+class SearchFragmentCompose : Fragment() {
+
+    private var isClickAllowed = true
+    private val clickDebounceDelay = 1000L
+    private val viewModel by viewModel<SearchViewModel>()
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+    ): View {
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                requireActivity().finishAffinity()
+            }
+        })
+
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MaterialTheme {
+                    SearchScreen(
+                        viewModel = viewModel,
+                        onTrackClick = ::handleTrackClick,
+                        onHistoryTrackClick = ::handleTrackClick,
+                        onClearHistory = viewModel::clearHistory,
+                        onRetry = { viewModel.searchDebounce(viewModel.lastQuery) },
+                        onClearSearch = { viewModel.searchDebounce("") }
+                    )
+                }
+            }
+        }
+    }
+
+    private fun handleTrackClick(track: Track) {
+        if (clickDebounce()) {
+            viewModel.saveTrackToHistory(track)
+            viewModel.saveForAudioPlayer(track)
+            viewLifecycleOwner.lifecycleScope.launch {
+                delay(1000)
+                findNavController().navigate(R.id.action_global_to_trackFragment)
+            }
+        }
+    }
+
+    private fun clickDebounce(): Boolean {
+        val current = isClickAllowed
+        if (isClickAllowed) {
+            isClickAllowed = false
+            viewLifecycleOwner.lifecycleScope.launch {
+                delay(clickDebounceDelay)
+                isClickAllowed = true
+            }
+        }
+        return current
+    }
+
+    @Composable
+    fun SearchScreen(
+        viewModel: SearchViewModel,
+        onTrackClick: (Track) -> Unit,
+        onHistoryTrackClick: (Track) -> Unit,
+        onClearHistory: () -> Unit,
+        onRetry: () -> Unit,
+        onClearSearch: () -> Unit
+    ) {
+        val state by viewModel.searchScreenState.observeAsState(SearchScreenState.Content(emptyList(), emptyList(), ""))
+        var query by viewModel.query
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(colorResource(R.color.defaultBackground))
+        ) {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.search),
+                        fontFamily = FontFamily(Font(R.font.ys_display_medium)),
+                        fontSize = dimensionResource(R.dimen.default_text_size).value.sp,
+                        color = colorResource(R.color.defaultTextColor)
+                    )
+                },
+                backgroundColor = Color.Transparent,
+                elevation = 0.dp
+            )
+
+            SearchInput(
+                query = query,
+                onQueryChange = { newQuery ->
+                    query = newQuery
+                    viewModel.searchDebounce(newQuery)
+                },
+                onClearSearch = {
+                    query = ""
+                    onClearSearch()
+                    viewModel.searchDebounce(query)
+                },
+                onDone = {}
+            )
+
+            when (state) {
+                is SearchScreenState.Loading -> LoadingIndicator()
+                is SearchScreenState.Content -> SearchContent(
+                    state = state as SearchScreenState.Content,
+                    query = query,
+                    onTrackClick = onTrackClick,
+                    onHistoryTrackClick = onHistoryTrackClick,
+                    onClearHistory = onClearHistory
+                )
+
+                is SearchScreenState.Error -> {
+                    val error = state as SearchScreenState.Error
+                    ErrorView(
+                        icon = painterResource(R.drawable.track_search_error),
+                        text = stringResource(R.string.connection_error),
+                        showRetry = error.showRefresh,
+                        onRetry = onRetry
+                    )
+                }
+            }
+        }
+    }
+
+    @Composable
+    fun LoadingIndicator() {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.TopCenter
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.padding(top = 150.dp),
+                color = colorResource(R.color.YP_Blue)
+            )
+        }
+    }
+
+    @Composable
+    fun SearchContent(
+        state: SearchScreenState.Content,
+        query: String,
+        onTrackClick: (Track) -> Unit,
+        onHistoryTrackClick: (Track) -> Unit,
+        onClearHistory: () -> Unit
+    ) {
+        if (state.tracks.isEmpty() && state.query.isNotBlank()) {
+            ErrorView(
+                icon = painterResource(R.drawable.track_not_found),
+                text = stringResource(R.string.nothing_found),
+                showRetry = false,
+                onRetry = {}
+            )
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 24.dp)
+            ) {
+                items(state.tracks) { track ->
+                    TrackItem(track = track, onClick = { onTrackClick(track) })
+                }
+            }
+        }
+
+        if (query.isEmpty() && state.historyTracks.isNotEmpty()) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = stringResource(R.string.search_history_header),
+                    color = colorResource(R.color.defaultTextColor),
+                    fontFamily = FontFamily(Font(R.font.ys_display_medium)),
+                    fontSize = 19.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 24.dp)
+                ) {
+                    items(state.historyTracks) { track ->
+                        TrackItem(track = track, onClick = { onHistoryTrackClick(track) })
+                    }
+                }
+                Button(
+                    onClick = onClearHistory,
+                    colors = ButtonDefaults.buttonColors(backgroundColor = colorResource(R.color.defaultTextColor)),
+                    shape = RoundedCornerShape(54.dp),
+                    contentPadding = PaddingValues(horizontal = 14.dp, vertical = 6.dp),
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(top = 24.dp, bottom = 16.dp)
+                        .height(40.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.clear_search),
+                        fontSize = 14.sp,
+                        fontFamily = FontFamily(Font(R.font.ys_display_medium)),
+                        color = colorResource(R.color.defaultBackground),
+                        letterSpacing = 0.sp
+                    )
+                }
+            }
+        }
+    }
+
+    @Composable
+    fun SearchInput(
+        query: String,
+        onQueryChange: (String) -> Unit,
+        onClearSearch: () -> Unit,
+        onDone: () -> Unit
+    ) {
+        Box(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(36.dp)
+                    .background(
+                        color = colorResource(R.color.searchPageInput),
+                        shape = RoundedCornerShape(8.dp)
+                    ),
+                contentAlignment = Alignment.CenterStart
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.search_small_svg),
+                        contentDescription = "Search",
+                        tint = colorResource(R.color.searchPagePlaceholder),
+                        modifier = Modifier.padding(start = 8.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Box(modifier = Modifier.weight(1f)) {
+                        if (query.isEmpty()) {
+                            Text(
+                                text = stringResource(R.string.search),
+                                color = colorResource(R.color.searchPagePlaceholder),
+                                fontFamily = FontFamily(Font(R.font.ys_display_regular)),
+                                fontSize = 14.sp,
+                                modifier = Modifier.align(Alignment.CenterStart)
+                            )
+                        }
+                        BasicTextField(
+                            value = query,
+                            onValueChange = onQueryChange,
+                            singleLine = true,
+                            textStyle = androidx.compose.ui.text.TextStyle(
+                                color = colorResource(R.color.YP_Black),
+                                fontFamily = FontFamily(Font(R.font.ys_display_regular)),
+                                fontSize = 14.sp
+                            ),
+                            cursorBrush = SolidColor(colorResource(R.color.YP_Blue)),
+                            keyboardActions = KeyboardActions(onDone = { onDone() }),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .align(Alignment.CenterStart)
+                        )
+                    }
+                    if (query.isNotEmpty()) {
+                        IconButton(onClick = onClearSearch) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.baseline_close),
+                                contentDescription = "Clear",
+                                tint = colorResource(R.color.searchPagePlaceholder)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Composable
+    fun ErrorView(icon: Painter, text: String, showRetry: Boolean, onRetry: () -> Unit) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 100.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(painter = icon, contentDescription = null, modifier = Modifier.size(120.dp), tint = Color.Unspecified)
+            Text(
+                text = text,
+                modifier = Modifier.padding(top = 16.dp),
+                color = colorResource(R.color.defaultTextColor),
+                fontFamily = FontFamily(Font(R.font.ys_display_medium)),
+                fontSize = 19.sp,
+                textAlign = TextAlign.Center
+            )
+            if (showRetry) {
+                Button(
+                    onClick = onRetry,
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(top = 24.dp, bottom = 16.dp)
+                        .height(40.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        backgroundColor = colorResource(R.color.defaultTextColor)
+                    ),
+                    shape = RoundedCornerShape(54.dp),
+                    contentPadding = PaddingValues(horizontal = 14.dp, vertical = 6.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.refresh),
+                        fontSize = 14.sp,
+                        fontFamily = FontFamily(Font(R.font.ys_display_medium)),
+                        color = colorResource(R.color.defaultBackground),
+                        textAlign = TextAlign.Center,
+                        letterSpacing = 0.sp
+                    )
+                }
+            }
+        }
+    }
+
+    @Composable
+    fun TrackItem(track: Track, onClick: () -> Unit) {
+        AndroidView(
+            modifier = Modifier
+                .fillMaxWidth(),
+            factory = { context ->
+                LayoutInflater.from(context).inflate(R.layout.track_item, null, false).apply {
+                    setOnClickListener { onClick() }
+                }
+            },
+            update = { view ->
+                val trackName = view.findViewById<TextView>(R.id.tvTrackName)
+                val trackArtist = view.findViewById<TextView>(R.id.tvTrackArtistName)
+                val trackTime = view.findViewById<TextView>(R.id.tvTrackTime)
+                val trackImage = view.findViewById<ImageView>(R.id.ivTrackImage)
+
+                trackName.text = track.trackName
+                trackArtist.text = track.artistName
+                trackTime.text = track.trackTime
+                Glide.with(view.context)
+                    .load(track.artworkUrl100)
+                    .placeholder(R.drawable.placeholder)
+                    .into(trackImage)
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/example/playlistmaker/search/ui/SearchFragmentCompose.kt
+++ b/app/src/main/java/com/example/playlistmaker/search/ui/SearchFragmentCompose.kt
@@ -4,8 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
-import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -16,14 +14,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -34,30 +30,28 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
-import com.bumptech.glide.Glide
 import com.example.playlistmaker.R
 import com.example.playlistmaker.search.domain.models.Track
 import com.example.playlistmaker.search.view_model.SearchScreenState
 import com.example.playlistmaker.search.view_model.SearchViewModel
 import com.example.playlistmaker.universalUiComponents.ActionButton
 import com.example.playlistmaker.universalUiComponents.CustomTopBar
+import com.example.playlistmaker.universalUiComponents.ErrorView
+import com.example.playlistmaker.universalUiComponents.LoadingIndicator
+import com.example.playlistmaker.universalUiComponents.TrackItem
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -170,19 +164,6 @@ class SearchFragmentCompose : Fragment() {
                     )
                 }
             }
-        }
-    }
-
-    @Composable
-    fun LoadingIndicator() {
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.TopCenter
-        ) {
-            CircularProgressIndicator(
-                modifier = Modifier.padding(top = 150.dp),
-                color = colorResource(R.color.YP_Blue)
-            )
         }
     }
 
@@ -311,53 +292,4 @@ class SearchFragmentCompose : Fragment() {
         }
     }
 
-    @Composable
-    fun ErrorView(icon: Painter, text: String, showRetry: Boolean, onRetry: () -> Unit) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 100.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Icon(painter = icon, contentDescription = null, modifier = Modifier.size(120.dp), tint = Color.Unspecified)
-            Text(
-                text = text,
-                modifier = Modifier.padding(top = 16.dp),
-                color = colorResource(R.color.defaultTextColor),
-                fontFamily = FontFamily(Font(R.font.ys_display_medium)),
-                fontSize = 19.sp,
-                textAlign = TextAlign.Center
-            )
-            if (showRetry) {
-                ActionButton(onClick = onRetry, text = stringResource(R.string.refresh))
-            }
-        }
-    }
-
-    @Composable
-    fun TrackItem(track: Track, onClick: () -> Unit) {
-        AndroidView(
-            modifier = Modifier
-                .fillMaxWidth(),
-            factory = { context ->
-                LayoutInflater.from(context).inflate(R.layout.track_item, null, false).apply {
-                    setOnClickListener { onClick() }
-                }
-            },
-            update = { view ->
-                val trackName = view.findViewById<TextView>(R.id.tvTrackName)
-                val trackArtist = view.findViewById<TextView>(R.id.tvTrackArtistName)
-                val trackTime = view.findViewById<TextView>(R.id.tvTrackTime)
-                val trackImage = view.findViewById<ImageView>(R.id.ivTrackImage)
-
-                trackName.text = track.trackName
-                trackArtist.text = track.artistName
-                trackTime.text = track.trackTime
-                Glide.with(view.context)
-                    .load(track.artworkUrl100)
-                    .placeholder(R.drawable.placeholder)
-                    .into(trackImage)
-            }
-        )
-    }
 }

--- a/app/src/main/java/com/example/playlistmaker/search/ui/SearchFragmentCompose.kt
+++ b/app/src/main/java/com/example/playlistmaker/search/ui/SearchFragmentCompose.kt
@@ -10,7 +10,6 @@ import androidx.activity.OnBackPressedCallback
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -24,14 +23,11 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -43,7 +39,6 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.Font
@@ -61,6 +56,8 @@ import com.example.playlistmaker.R
 import com.example.playlistmaker.search.domain.models.Track
 import com.example.playlistmaker.search.view_model.SearchScreenState
 import com.example.playlistmaker.search.view_model.SearchViewModel
+import com.example.playlistmaker.universalUiComponents.ActionButton
+import com.example.playlistmaker.universalUiComponents.CustomTopBar
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -137,18 +134,7 @@ class SearchFragmentCompose : Fragment() {
                 .fillMaxSize()
                 .background(colorResource(R.color.defaultBackground))
         ) {
-            TopAppBar(
-                title = {
-                    Text(
-                        text = stringResource(R.string.search),
-                        fontFamily = FontFamily(Font(R.font.ys_display_medium)),
-                        fontSize = dimensionResource(R.dimen.default_text_size).value.sp,
-                        color = colorResource(R.color.defaultTextColor)
-                    )
-                },
-                backgroundColor = Color.Transparent,
-                elevation = 0.dp
-            )
+            CustomTopBar(titleText = stringResource(R.string.search))
 
             SearchInput(
                 query = query,
@@ -243,28 +229,14 @@ class SearchFragmentCompose : Fragment() {
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(top = 24.dp)
+                        .weight(1f)
                 ) {
                     items(state.historyTracks) { track ->
                         TrackItem(track = track, onClick = { onHistoryTrackClick(track) })
                     }
-                }
-                Button(
-                    onClick = onClearHistory,
-                    colors = ButtonDefaults.buttonColors(backgroundColor = colorResource(R.color.defaultTextColor)),
-                    shape = RoundedCornerShape(54.dp),
-                    contentPadding = PaddingValues(horizontal = 14.dp, vertical = 6.dp),
-                    modifier = Modifier
-                        .align(Alignment.CenterHorizontally)
-                        .padding(top = 24.dp, bottom = 16.dp)
-                        .height(40.dp)
-                ) {
-                    Text(
-                        text = stringResource(R.string.clear_search),
-                        fontSize = 14.sp,
-                        fontFamily = FontFamily(Font(R.font.ys_display_medium)),
-                        color = colorResource(R.color.defaultBackground),
-                        letterSpacing = 0.sp
-                    )
+                    item {
+                        ActionButton(onClick = onClearHistory, text = stringResource(R.string.clear_search))
+                    }
                 }
             }
         }
@@ -357,27 +329,7 @@ class SearchFragmentCompose : Fragment() {
                 textAlign = TextAlign.Center
             )
             if (showRetry) {
-                Button(
-                    onClick = onRetry,
-                    modifier = Modifier
-                        .align(Alignment.CenterHorizontally)
-                        .padding(top = 24.dp, bottom = 16.dp)
-                        .height(40.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        backgroundColor = colorResource(R.color.defaultTextColor)
-                    ),
-                    shape = RoundedCornerShape(54.dp),
-                    contentPadding = PaddingValues(horizontal = 14.dp, vertical = 6.dp)
-                ) {
-                    Text(
-                        text = stringResource(R.string.refresh),
-                        fontSize = 14.sp,
-                        fontFamily = FontFamily(Font(R.font.ys_display_medium)),
-                        color = colorResource(R.color.defaultBackground),
-                        textAlign = TextAlign.Center,
-                        letterSpacing = 0.sp
-                    )
-                }
+                ActionButton(onClick = onRetry, text = stringResource(R.string.refresh))
             }
         }
     }

--- a/app/src/main/java/com/example/playlistmaker/search/view_model/SearchViewModel.kt
+++ b/app/src/main/java/com/example/playlistmaker/search/view_model/SearchViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.playlistmaker.search.view_model
 
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -21,37 +22,44 @@ class SearchViewModel(private val trackInteractor: TrackInteractor) : ViewModel(
     private val screenState = MutableLiveData<SearchScreenState>(SearchScreenState.Loading)
     val searchScreenState: LiveData<SearchScreenState> = screenState
 
+    var query = mutableStateOf("")
+        private set
+
+
     init {
         loadSearchHistory()
     }
 
     private fun searchTracks(query: String) {
         viewModelScope.launch {
-            if (query.isNotBlank()) {
-                screenState.value = SearchScreenState.Loading
-            }
+
+            screenState.value = SearchScreenState.Loading
+
 
             trackInteractor.searchTracks(query).collect { actualResult ->
-                    if (query.isBlank()) {
-                        loadSearchHistory()
-                    } else if (actualResult.isError) {
-                        screenState.value = SearchScreenState.Error(showRefresh = true)
-                    } else {
-                        val currentHistory = when (val state = screenState.value) {
-                            is SearchScreenState.Content -> state.historyTracks
-                            else -> emptyList()
-                        }
-
-                        screenState.value = SearchScreenState.Content(tracks = actualResult.tracks,
-                            historyTracks = currentHistory,
-                            query = query)
+                if (query.isBlank()) {
+                    delay(300)
+                    loadSearchHistory()
+                } else if (actualResult.isError) {
+                    screenState.value = SearchScreenState.Error(showRefresh = true)
+                } else {
+                    val currentHistory = when (val state = screenState.value) {
+                        is SearchScreenState.Content -> state.historyTracks
+                        else -> emptyList()
                     }
+
+                    screenState.value = SearchScreenState.Content(
+                        tracks = actualResult.tracks,
+                        historyTracks = currentHistory,
+                        query = query
+                    )
                 }
+            }
         }
     }
 
     private var searchJob: Job? = null
-    private var lastQuery = ""
+    var lastQuery = ""
 
     fun searchDebounce(query: String) {
         if (query == lastQuery && screenState.value !is SearchScreenState.Error && screenState.value != null) {

--- a/app/src/main/java/com/example/playlistmaker/settings/ui/SettingsFragmentCompose.kt
+++ b/app/src/main/java/com/example/playlistmaker/settings/ui/SettingsFragmentCompose.kt
@@ -1,0 +1,175 @@
+package com.example.playlistmaker.settings.ui
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.Switch
+import androidx.compose.material.SwitchDefaults
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.fragment.app.Fragment
+import com.example.playlistmaker.R
+import com.example.playlistmaker.settings.view_model.SettingsViewModel
+import org.koin.androidx.viewmodel.ext.android.viewModel
+
+class SettingsFragmentCompose : Fragment() {
+
+    private val settingsViewModel by viewModel<SettingsViewModel>()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+
+        return ComposeView(requireContext()).apply {
+            setContent {
+                val isDarkTheme by settingsViewModel.isDarkTheme.observeAsState(false)
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(color = colorResource(id = R.color.defaultBackground))
+                ) {
+                    TopAppBar(
+                        title = {
+                            Text(
+                                text = stringResource(R.string.settings),
+                                fontFamily = FontFamily(Font(R.font.ys_display_medium)),
+                                fontSize = dimensionResource(R.dimen.default_text_size).value.sp,
+                                color = colorResource(R.color.defaultTextColor)
+                            )
+                        },
+                        backgroundColor = Color.Transparent,
+                        elevation = 0.dp
+                    )
+
+                    Spacer(modifier = Modifier.height(20.dp))
+
+                    // Dark Theme Switch
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = stringResource(R.string.dark_theme),
+                            fontFamily = FontFamily(Font(R.font.ys_display_regular)),
+                            fontSize = 16.sp,
+                            color = colorResource(id = R.color.defaultTextColor),
+                            modifier = Modifier.weight(1f)
+                        )
+                        Switch(
+                            checked = isDarkTheme,
+                            onCheckedChange = { settingsViewModel.switchTheme(it) },
+                            colors = SwitchDefaults.colors(
+                                checkedThumbColor = colorResource(id = R.color.switchThumbActive),  // соответствует state_checked="true"
+                                uncheckedThumbColor = colorResource(id = R.color.switchTumbler),
+                                checkedTrackColor = colorResource(id = R.color.switchBackgroundActive),  // трек включен
+                                uncheckedTrackColor = colorResource(id = R.color.switchBackground)// default
+                            ),
+                            modifier = Modifier.offset(x = 12.dp)
+                        )
+                    }
+                    SettingsMenuItem(
+                        text = stringResource(R.string.share_app),
+                        iconRes = R.drawable.share_svg,
+                        onClick = { shareApp() }
+                    )
+                    SettingsMenuItem(
+                        text = stringResource(R.string.write_to_support),
+                        iconRes = R.drawable.support_svg,
+                        onClick = { sendSupportEmail() }
+                    )
+                    SettingsMenuItem(
+                        text = stringResource(R.string.user_agreement),
+                        iconRes = R.drawable.arrow_forward,
+                        onClick = { openUserAgreement() }
+                    )
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun SettingsMenuItem(
+        text: String,
+        @DrawableRes iconRes: Int,
+        onClick: () -> Unit
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 20.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = text,
+                fontFamily = FontFamily(Font(R.font.ys_display_regular)),
+                fontSize = 16.sp,
+                color = colorResource(id = R.color.defaultTextColor),
+                modifier = Modifier.weight(1f)
+            )
+            Icon(
+                painter = painterResource(id = iconRes),
+                contentDescription = null,
+                tint = Color.Unspecified
+            )
+        }
+    }
+
+    private fun shareApp() {
+        val shareIntent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, getString(R.string.android_course_link))
+        }
+        startActivity(Intent.createChooser(shareIntent, getString(R.string.share_from)))
+    }
+
+    private fun sendSupportEmail() {
+        val emailAddress = getString(R.string.student_email)
+        val emailSubject = getString(R.string.email_subject)
+        val emailBody = getString(R.string.email_body)
+        val uri = Uri.parse("mailto:$emailAddress?subject=${Uri.encode(emailSubject)}&body=${Uri.encode(emailBody)}")
+        val emailIntent = Intent(Intent.ACTION_SENDTO, uri)
+        startActivity(emailIntent)
+    }
+
+    private fun openUserAgreement() {
+        val url = getString(R.string.user_agreements)
+        val termsIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        startActivity(termsIntent)
+    }
+}

--- a/app/src/main/java/com/example/playlistmaker/settings/ui/SettingsFragmentCompose.kt
+++ b/app/src/main/java/com/example/playlistmaker/settings/ui/SettingsFragmentCompose.kt
@@ -21,7 +21,6 @@ import androidx.compose.material.Icon
 import androidx.compose.material.Switch
 import androidx.compose.material.SwitchDefaults
 import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -30,7 +29,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.Font
@@ -40,6 +38,7 @@ import androidx.compose.ui.unit.sp
 import androidx.fragment.app.Fragment
 import com.example.playlistmaker.R
 import com.example.playlistmaker.settings.view_model.SettingsViewModel
+import com.example.playlistmaker.universalUiComponents.CustomTopBar
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class SettingsFragmentCompose : Fragment() {
@@ -61,18 +60,7 @@ class SettingsFragmentCompose : Fragment() {
                         .fillMaxSize()
                         .background(color = colorResource(id = R.color.defaultBackground))
                 ) {
-                    TopAppBar(
-                        title = {
-                            Text(
-                                text = stringResource(R.string.settings),
-                                fontFamily = FontFamily(Font(R.font.ys_display_medium)),
-                                fontSize = dimensionResource(R.dimen.default_text_size).value.sp,
-                                color = colorResource(R.color.defaultTextColor)
-                            )
-                        },
-                        backgroundColor = Color.Transparent,
-                        elevation = 0.dp
-                    )
+                    CustomTopBar(titleText = stringResource(R.string.settings))
 
                     Spacer(modifier = Modifier.height(20.dp))
 

--- a/app/src/main/java/com/example/playlistmaker/universalUiComponents/Components.kt
+++ b/app/src/main/java/com/example/playlistmaker/universalUiComponents/Components.kt
@@ -1,0 +1,70 @@
+package com.example.playlistmaker.universalUiComponents
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.playlistmaker.R
+
+@Composable
+fun CustomTopBar(
+    titleText: String,
+) {
+    TopAppBar(
+        title = {
+            Text(
+                text = titleText,
+                fontFamily = FontFamily(Font(R.font.ys_display_medium)),
+                fontSize = dimensionResource(R.dimen.default_text_size).value.sp,
+                color = colorResource(R.color.defaultTextColor)
+            )
+        },
+        backgroundColor = Color.Transparent,
+        elevation = 0.dp,
+    )
+}
+
+@Composable
+fun ActionButton(
+    text: String,
+    onClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 24.dp, bottom = 16.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Button(
+            onClick = onClick,
+            colors = ButtonDefaults.buttonColors(backgroundColor = colorResource(R.color.defaultTextColor)),
+            shape = RoundedCornerShape(54.dp),
+            contentPadding = PaddingValues(horizontal = 14.dp, vertical = 6.dp),
+            modifier = Modifier.height(40.dp)
+        ) {
+            Text(
+                text = text,
+                fontSize = 14.sp,
+                fontFamily = FontFamily(Font(R.font.ys_display_medium)),
+                color = colorResource(R.color.defaultBackground),
+                letterSpacing = 0.sp
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/playlistmaker/universalUiComponents/Components.kt
+++ b/app/src/main/java/com/example/playlistmaker/universalUiComponents/Components.kt
@@ -1,19 +1,24 @@
 package com.example.playlistmaker.universalUiComponents
 
-import android.view.LayoutInflater
-import android.widget.ImageView
-import android.widget.TextView
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Card
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
@@ -23,16 +28,18 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.viewinterop.AndroidView
-import com.bumptech.glide.Glide
+import coil.compose.AsyncImage
 import com.example.playlistmaker.R
 import com.example.playlistmaker.search.domain.models.Track
 
@@ -84,31 +91,70 @@ fun ActionButton(
 }
 
 @Composable
-fun TrackItem(track: Track, onClick: () -> Unit) {
-    AndroidView(
+fun TrackItem(
+    track: Track,
+    onClick: () -> Unit
+) {
+    Row(
         modifier = Modifier
-            .fillMaxWidth(),
-        factory = { context ->
-            LayoutInflater.from(context).inflate(R.layout.track_item, null, false).apply {
-                setOnClickListener { onClick() }
-            }
-        },
-        update = { view ->
-            val trackName = view.findViewById<TextView>(R.id.tvTrackName)
-            val trackArtist = view.findViewById<TextView>(R.id.tvTrackArtistName)
-            val trackTime = view.findViewById<TextView>(R.id.tvTrackTime)
-            val trackImage = view.findViewById<ImageView>(R.id.ivTrackImage)
-
-            trackName.text = track.trackName
-            trackArtist.text = track.artistName
-            trackTime.text = track.trackTime
-            Glide.with(view.context)
-                .load(track.artworkUrl100)
-                .placeholder(R.drawable.placeholder)
-                .into(trackImage)
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Обложка
+        Card(
+            shape = RoundedCornerShape(4.dp),
+            elevation = 0.dp,
+            modifier = Modifier.size(45.dp)
+        ) {
+            AsyncImage(
+                model = track.artworkUrl100 ?: R.drawable.placeholder,
+                contentDescription = null,
+                contentScale = ContentScale.Crop
+            )
         }
-    )
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        // Column для обоих текстов
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight(),
+            verticalArrangement = Arrangement.Center // центрируем всю колонку по вертикали
+        ) {
+            Column(modifier = Modifier) {
+                Text(
+                    text = track.trackName ?: "Unknown",
+                    fontSize = 16.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    fontFamily = FontFamily(Font(R.font.ys_display_regular)),
+                    color = colorResource(id = R.color.defaultTextColor)
+                )
+            }
+            Column {
+                Text(
+                    text = "${track.artistName ?: "Unknown"} • ${track.trackTime ?: "00:00"}",
+                    fontSize = 11.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    fontFamily = FontFamily(Font(R.font.ys_display_regular)),
+                    color = colorResource(id = R.color.trackAdditionalText)
+                )
+            }
+        }
+
+        // Стрелка
+        Image(
+            painter = painterResource(id = R.drawable.arrow_forward),
+            contentDescription = null,
+            modifier = Modifier.size(16.dp)
+        )
+    }
 }
+
 
 @Composable
 fun ErrorView(

--- a/app/src/main/java/com/example/playlistmaker/universalUiComponents/Components.kt
+++ b/app/src/main/java/com/example/playlistmaker/universalUiComponents/Components.kt
@@ -1,26 +1,40 @@
 package com.example.playlistmaker.universalUiComponents
 
+import android.view.LayoutInflater
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.bumptech.glide.Glide
 import com.example.playlistmaker.R
+import com.example.playlistmaker.search.domain.models.Track
 
 @Composable
 fun CustomTopBar(
@@ -66,5 +80,75 @@ fun ActionButton(
                 letterSpacing = 0.sp
             )
         }
+    }
+}
+
+@Composable
+fun TrackItem(track: Track, onClick: () -> Unit) {
+    AndroidView(
+        modifier = Modifier
+            .fillMaxWidth(),
+        factory = { context ->
+            LayoutInflater.from(context).inflate(R.layout.track_item, null, false).apply {
+                setOnClickListener { onClick() }
+            }
+        },
+        update = { view ->
+            val trackName = view.findViewById<TextView>(R.id.tvTrackName)
+            val trackArtist = view.findViewById<TextView>(R.id.tvTrackArtistName)
+            val trackTime = view.findViewById<TextView>(R.id.tvTrackTime)
+            val trackImage = view.findViewById<ImageView>(R.id.ivTrackImage)
+
+            trackName.text = track.trackName
+            trackArtist.text = track.artistName
+            trackTime.text = track.trackTime
+            Glide.with(view.context)
+                .load(track.artworkUrl100)
+                .placeholder(R.drawable.placeholder)
+                .into(trackImage)
+        }
+    )
+}
+
+@Composable
+fun ErrorView(icon: Painter, text: String, showRetry: Boolean, onRetry: () -> Unit) {
+    Box(
+        modifier = Modifier.fillMaxSize(),   // занимаем всё пространство
+        contentAlignment = Alignment.Center  // и центрируем содержимое
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                painter = icon,
+                contentDescription = null,
+                modifier = Modifier.size(120.dp),
+                tint = Color.Unspecified
+            )
+            Text(
+                text = text,
+                modifier = Modifier.padding(top = 16.dp),
+                color = colorResource(R.color.defaultTextColor),
+                fontFamily = FontFamily(Font(R.font.ys_display_medium)),
+                fontSize = 19.sp,
+                textAlign = TextAlign.Center
+            )
+            if (showRetry) {
+                ActionButton(onClick = onRetry, text = stringResource(R.string.refresh))
+            }
+        }
+    }
+}
+
+@Composable
+fun LoadingIndicator() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.TopCenter
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.padding(top = 150.dp),
+            color = colorResource(R.color.YP_Blue)
+        )
     }
 }

--- a/app/src/main/java/com/example/playlistmaker/universalUiComponents/Components.kt
+++ b/app/src/main/java/com/example/playlistmaker/universalUiComponents/Components.kt
@@ -2,6 +2,7 @@ package com.example.playlistmaker.universalUiComponents
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -23,7 +24,9 @@ import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -98,7 +101,7 @@ fun TrackItem(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
+            .clickable(onClick = onClick, indication = rememberRipple(bounded = true), interactionSource = remember { MutableInteractionSource() })
             .padding(horizontal = 16.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -154,7 +157,6 @@ fun TrackItem(
         )
     }
 }
-
 
 @Composable
 fun ErrorView(

--- a/app/src/main/java/com/example/playlistmaker/universalUiComponents/Components.kt
+++ b/app/src/main/java/com/example/playlistmaker/universalUiComponents/Components.kt
@@ -111,31 +111,33 @@ fun TrackItem(track: Track, onClick: () -> Unit) {
 }
 
 @Composable
-fun ErrorView(icon: Painter, text: String, showRetry: Boolean, onRetry: () -> Unit) {
-    Box(
-        modifier = Modifier.fillMaxSize(),   // занимаем всё пространство
-        contentAlignment = Alignment.Center  // и центрируем содержимое
+fun ErrorView(
+    icon: Painter,
+    text: String,
+    showRetry: Boolean,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Icon(
-                painter = icon,
-                contentDescription = null,
-                modifier = Modifier.size(120.dp),
-                tint = Color.Unspecified
-            )
-            Text(
-                text = text,
-                modifier = Modifier.padding(top = 16.dp),
-                color = colorResource(R.color.defaultTextColor),
-                fontFamily = FontFamily(Font(R.font.ys_display_medium)),
-                fontSize = 19.sp,
-                textAlign = TextAlign.Center
-            )
-            if (showRetry) {
-                ActionButton(onClick = onRetry, text = stringResource(R.string.refresh))
-            }
+        Icon(
+            painter = icon,
+            contentDescription = null,
+            modifier = Modifier.size(120.dp),
+            tint = Color.Unspecified
+        )
+        Text(
+            text = text,
+            modifier = Modifier.padding(top = 16.dp),
+            color = colorResource(R.color.defaultTextColor),
+            fontFamily = FontFamily(Font(R.font.ys_display_medium)),
+            fontSize = 19.sp,
+            textAlign = TextAlign.Center
+        )
+        if (showRetry) {
+            ActionButton(onClick = onRetry, text = stringResource(R.string.refresh))
         }
     }
 }

--- a/app/src/main/res/navigation/main_navigation_graph.xml
+++ b/app/src/main/res/navigation/main_navigation_graph.xml
@@ -56,7 +56,7 @@
 
     <fragment
         android:id="@+id/settingsFragment"
-        android:name="com.example.playlistmaker.settings.ui.SettingsFragment"
+        android:name="com.example.playlistmaker.settings.ui.SettingsFragmentCompose"
         android:label="SettingsFragment" />
 
     <fragment

--- a/app/src/main/res/navigation/main_navigation_graph.xml
+++ b/app/src/main/res/navigation/main_navigation_graph.xml
@@ -17,7 +17,7 @@
     </fragment>
     <fragment
         android:id="@+id/mediaFragment"
-        android:name="com.example.playlistmaker.media.ui.MediaFragment"
+        android:name="com.example.playlistmaker.media.ui.MediaFragmentCompose"
         android:label="MediaFragment">
         <action
             android:id="@+id/action_media_to_newPlaylist"

--- a/app/src/main/res/navigation/main_navigation_graph.xml
+++ b/app/src/main/res/navigation/main_navigation_graph.xml
@@ -5,7 +5,7 @@
     app:startDestination="@id/searchFragment">
     <fragment
         android:id="@+id/searchFragment"
-        android:name="com.example.playlistmaker.search.ui.SearchFragment"
+        android:name="com.example.playlistmaker.search.ui.SearchFragmentCompose"
         android:label="SearchFragment">
         <action
             android:id="@+id/action_searchFragment_to_trackFragment"


### PR DESCRIPTION
Уровень 1. Замена UI нескольких экранов на Compose с сохранением традиционного подхода к навигации
На этом уровне у вас сохраняется текущая навигация, реализованная с использованием паттерна Single Activity, где каждый экран представляет отдельный Fragment.
Задача — сделать так, чтобы в самих фрагментах для вёрстки и взаимодействия с элементами пользовательского интерфейса не использовались XML-файлы и View-элементы. Всё должно быть реализовано только за счёт Composable-функций. 
В рамках этой задачи вы должны заменить UI с View на Compose для следующих экранов приложения:
«Поиск» (поиск треков и история поиска).
«Медиатека».
«Настройки».